### PR TITLE
Feature dashboard report total interviews

### DIFF
--- a/src/actions/total-weekly/total-weekly.actions.ts
+++ b/src/actions/total-weekly/total-weekly.actions.ts
@@ -1,0 +1,19 @@
+import { interviewClient } from "../../axios/sms-clients/interview-client";
+
+export const TOTAL_WEEKLY_TYPES = {
+  SET_INTERVIEW_LIST: 'T.W.T_SET_INTERVIEW_LIST'
+}
+
+export const getInterviews = (date: number | Date) => async (dispatch) => {
+  try {
+    let response = await interviewClient.getCalendarWeek(date);
+    if (response.status === 200) {
+      dispatch({
+        type: TOTAL_WEEKLY_TYPES.SET_INTERVIEW_LIST,
+        payload: response.data
+      });
+    }
+  } catch(err) {
+    console.log('Retrieval of calendar week interviews failed');
+  }
+}

--- a/src/actions/total-weekly/total-weekly.actions.ts
+++ b/src/actions/total-weekly/total-weekly.actions.ts
@@ -1,4 +1,5 @@
 import { interviewClient } from "../../axios/sms-clients/interview-client";
+import { Interview } from "../../model/Interview.model";
 
 export const TOTAL_WEEKLY_TYPES = {
   SET_INTERVIEW_LIST: 'T.W.T_SET_INTERVIEW_LIST'
@@ -8,9 +9,24 @@ export const getInterviews = (date: number | Date) => async (dispatch) => {
   try {
     let response = await interviewClient.getCalendarWeek(date);
     if (response.status === 200) {
+      let interviewList: Interview[] = response.data;
+      let totalScheduled = 0;
+      let totalNotified = 0;
+      let totalReviewed = 0;
+      for (let interview of interviewList) {
+        if (interview.scheduled !== null) totalScheduled++;
+        if (interview.notified !== null) totalNotified++;
+        if (interview.reviewed !== null) totalReviewed++;
+      }
+      let payload = {
+        interviewList,
+        totalScheduled,
+        totalNotified,
+        totalReviewed
+      }
       dispatch({
         type: TOTAL_WEEKLY_TYPES.SET_INTERVIEW_LIST,
-        payload: response.data
+        payload
       });
     }
   } catch(err) {

--- a/src/axios/sms-clients/interview-client.ts
+++ b/src/axios/sms-clients/interview-client.ts
@@ -99,6 +99,6 @@ export const interviewClient = {
         // either one for convenience or to account for user error
         let epochDate = typeof date === 'number' ? date : date.getTime();
 
-        return await smsClient.get(`${interviewContext}/${epochDate}`);
+        return await smsClient.get(`${interviewContext}/CalendarWeek/${epochDate}`);
     }
 }

--- a/src/axios/sms-clients/interview-client.ts
+++ b/src/axios/sms-clients/interview-client.ts
@@ -86,10 +86,19 @@ export const interviewClient = {
     },
 
     fetchInterviewFeedback: async (interviewId: number) => {
-        return await smsClient.get(interviewContext + `/Feedback/InterviewId/${interviewId}`);;
+        return await smsClient.get(interviewContext + `/Feedback/InterviewId/${interviewId}`);
     },
 
     markInterviewAsReviewed: (id: number) => {
         return smsClient.get(interviewContext + '/markReviewed/' + id);
+    },
+    
+    getCalendarWeek: async (date: number | Date) => {
+
+        // Pass an epoch date number instead of a Date object, but accept
+        // either one for convenience or to account for user error
+        let epochDate = typeof date === 'number' ? date : date.getTime();
+
+        return await smsClient.get(`${interviewContext}/${epochDate}`);
     }
 }

--- a/src/components/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/src/components/dashboard/dashboard-nav/DashboardNav.tsx
@@ -6,10 +6,12 @@ import Navbar from 'reactstrap/lib/Navbar';
 import { IAuthState } from '../../../reducers/management';
 import { connect } from 'react-redux';
 import { IState } from '../../../reducers';
+import { getInterviews } from '../../../actions/total-weekly/total-weekly.actions';
 
 interface ISurveyNavComponentProps extends RouteComponentProps {
   updateSurveyTable: (group: string) => void,
   toggleCreateUserModal: () => void,
+  getWeeklyInterviews: (date: number | Date) => void,
   manage: string,
   auth: IAuthState
 }
@@ -20,7 +22,7 @@ class DashboardNav extends React.Component<ISurveyNavComponentProps, any> {
   }
 
   componentDidMount() {
-    
+    this.props.getWeeklyInterviews(new Date());
   
   }
   // returns active if the role provided in the route is the routeName provided
@@ -85,4 +87,8 @@ const mapStateToProps = (state: IState)  => ({
   auth: state.managementState.auth
 })
 
-export default connect(mapStateToProps)(DashboardNav);
+const mapDispatchToProps = {
+  getWeeklyInterviews: getInterviews
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DashboardNav);

--- a/src/components/dashboard/modules/numInterviews/NumInterviews.scss
+++ b/src/components/dashboard/modules/numInterviews/NumInterviews.scss
@@ -1,0 +1,13 @@
+.title {
+  text-align: center;
+}
+
+.content {
+  display: flex;
+  justify-content: space-evenly;
+}
+
+.footer-nav {
+  display: flex;
+  justify-content: center;
+}

--- a/src/components/dashboard/modules/numInterviews/NumInterviews.tsx
+++ b/src/components/dashboard/modules/numInterviews/NumInterviews.tsx
@@ -7,7 +7,7 @@ import { Interview } from '../../../../model/Interview.model';
 import NumInterviewsChart from './NumInterviewsChart';
 import './NumInterviews.scss';
 
-interface myProps extends RouteComponentProps<{}> {
+interface INumInterviewsProps extends RouteComponentProps<{}> {
     WrappedComponent: any;
     interviewList: Interview[];
     totalScheduled: number;
@@ -16,14 +16,14 @@ interface myProps extends RouteComponentProps<{}> {
     getWeeklyInterviews: (date: number | Date) => void;
 }
 
-interface myState {
+interface INumInterviewsState {
     currentWeek: Date;
     places: object;
     clients: object;
 }
 
-class NumInterviews extends Component<myProps,myState> {
-    constructor(props: myProps) {
+class NumInterviews extends Component<INumInterviewsProps,INumInterviewsState> {
+    constructor(props: INumInterviewsProps) {
         super(props);
         this.state = {
             currentWeek: new Date(),

--- a/src/components/dashboard/modules/numInterviews/NumInterviews.tsx
+++ b/src/components/dashboard/modules/numInterviews/NumInterviews.tsx
@@ -2,21 +2,167 @@ import React, { Component } from 'react'
 import { RouteComponentProps } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { IState } from '../../../../reducers';
+import { getInterviews } from '../../../../actions/total-weekly/total-weekly.actions';
+import { Interview } from '../../../../model/Interview.model';
+import NumInterviewsChart from './NumInterviewsChart';
+import './NumInterviews.scss';
 
 interface myProps extends RouteComponentProps<{}> {
     WrappedComponent: any;
+    interviewList: Interview[];
+    totalScheduled: number;
+    totalNotified: number;
+    totalReviewed: number;
+    getWeeklyInterviews: (date: number | Date) => void;
 }
-class NumInterviews extends Component<myProps,any> {
+
+interface myState {
+    currentWeek: Date;
+    places: object;
+    clients: object;
+}
+
+class NumInterviews extends Component<myProps,myState> {
+    constructor(props: myProps) {
+        super(props);
+        this.state = {
+            currentWeek: new Date(),
+            places: [],
+            clients: []
+        }
+    }
+
+    getWeekOf = (date: Date) => {
+        const newDate = new Date(
+            date.getTime() - // Start with current time
+            date.getDay() * 86400000 - // Get sunday
+            date.getHours() * 3600000 - // Get midnight
+            date.getMinutes() * 60000 - // Get beginning of hour
+            date.getSeconds() * 1000 - // Get beginning of minute
+            date.getMilliseconds()); // Get beginning of second
+        
+        return newDate.toDateString().substr(4);
+    }
+
+    getNextWeeklySummary = (date: Date) => {
+        date.setDate(date.getDate() + 7);
+        this.getWeeklySummary(date);
+    }
+
+    getPreviousWeeklySummary = (date: Date) => {
+        date.setDate(date.getDate() - 7);
+        this.getWeeklySummary(date);
+    }
+
+    getWeeklySummary = (date: Date) => {
+        this.props.getWeeklyInterviews(date);
+        this.setState({
+            ...this.state,
+            currentWeek: date
+        });
+    }
+
+    listToBuildable = (): object => {
+        let buildable = {};
+        buildable["Total Scheduled"] = this.props.totalScheduled;
+        buildable["Total Notified"] = this.props.totalNotified;
+        buildable["Total Reviewed"] = this.props.totalReviewed;
+        return buildable;
+    }
+
+    buildBarProps = (buildable: object, title: string, sub: string) => {
+        let keys: string[] = Object.keys(buildable);
+        let values: number[] = Object.values(buildable);
+        let possibleColors = [
+            'rgba(127, 255, 63, 0.6)',
+            'rgba(63, 127, 255, 0.6)',
+            'rgba(255, 63, 127, 0.6)',
+            'rgba(63, 255, 127, 0.6)',
+            'rgba(127, 63, 255, 0.6)',
+            'rgba(255, 127, 63, 0.6)'
+        ]
+        let backgroundColor: string[] = []
+        for (let i = 0; i < keys.length; i++) {
+            backgroundColor.push(possibleColors[i % 6])
+        }
+        let data = {
+            labels: keys,
+            datasets: [{
+                label: [sub],
+                data: values,
+                backgroundColor
+            }]
+        };
+        let options = {
+            title: {
+                display: true,
+                text: title,
+                fontSize: 25
+            },
+            legend: {
+                display: true,
+                position: 'bottom'
+            },
+            maintainAspectRatio: false,
+            scales: {
+                yAxes: [{
+                    ticks: {
+                        beginAtZero: true
+                    }
+                }]
+            }
+        }
+        return {data, options};
+    }
+
     render() {
+        let places: object = {};
+        let clients: object = {};
+        for (let interview of this.props.interviewList) {
+            let { place } = interview;
+            let { clientName } = interview.client;
+            if (places[place]) {
+                places[place]++;
+            } else {
+                places[place] = 1;
+            }
+            if (clients[clientName]) {
+                clients[clientName]++;
+            } else {
+                clients[clientName] = 1;
+            }
+        }
         return (
-            <div>
-                ●	Total number of interviews in the last week
+            <div className="NumInterviews">
+                <div className="title rev-background-color">
+                    Total number of interviews for the week of {this.getWeekOf(this.state.currentWeek)}
+                </div>
+                <div className="content">
+                    <div className="chart">
+                        <NumInterviewsChart info={this.buildBarProps(this.listToBuildable(), "Weekly Interview Summary", "Total Weekly Interview Summary")} />
+                        <NumInterviewsChart info={this.buildBarProps(places, "Branch Information", "Interview Reporting By Branch")} />
+                        <NumInterviewsChart info={this.buildBarProps(clients, "Client Breakdown", "Weekly Client Interviews")} />
+                    </div>
+                </div>
+                <div className="footer-nav">
+                    <button type="button" className="rev-background-color div-child btn btn-secondary" onClick={() => this.getPreviousWeeklySummary(this.state.currentWeek)}>Prev</button>&nbsp;
+                    <button type="button" className="rev-background-color div-child btn btn-secondary" onClick={() => this.getWeeklySummary(new Date())}>Current Week</button>&nbsp;
+                    <button type="button" className="rev-background-color div-child btn btn-secondary" onClick={() => this.getNextWeeklySummary(this.state.currentWeek)}>Next</button>
+                </div>
             </div>
         )
     }
 }
 const mapStateToProps = (state: IState) => ({
-    auth: state.managementState.auth
+    auth: state.managementState.auth,
+    interviewList: state.interviewState.totalWeekly.interviewList,
+    totalScheduled: state.interviewState.totalWeekly.totalScheduled,
+    totalNotified: state.interviewState.totalWeekly.totalNotified,
+    totalReviewed: state.interviewState.totalWeekly.totalReviewed
 });
 
-export default connect(mapStateToProps)(NumInterviews);
+const mapDispatchToProps = {
+    getWeeklyInterviews: getInterviews // using a different name locally for clarity
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NumInterviews);

--- a/src/components/dashboard/modules/numInterviews/NumInterviewsChart.tsx
+++ b/src/components/dashboard/modules/numInterviews/NumInterviewsChart.tsx
@@ -1,0 +1,53 @@
+import React, { Component } from 'react';
+import { Bar } from 'react-chartjs-2';
+
+interface INumIntervewsChartProps {
+  info: {
+    data: {
+      labels: string[];
+      datasets: {
+        label: string[];
+        data: number[];
+        backgroundColor: string[];
+      }[];
+    };
+    options: {
+      title: {
+        display: boolean;
+        text: string;
+        fontSize: number;
+      },
+      legend: {
+        display: boolean;
+        position: string;
+      },
+      maintainAspectRatio: boolean;
+      scales: {
+        yAxes: {
+          ticks: {
+            beginAtZero: boolean;
+          };
+        }[];
+      };
+    };
+  }
+}
+
+class NumInterviewsChart extends Component<INumIntervewsChartProps, any> {
+  render() {
+    const graphStyle = {
+      maxWidth: 700,
+      height: 350,
+      margin: '0 auto',
+      padding: 30,
+      display: 'inline-block',
+    }
+    return (
+      <div style = {graphStyle} className="summary">
+        <Bar data={this.props.info.data} options={this.props.info.options} />
+      </div>
+    )
+  }
+}
+
+export default NumInterviewsChart;

--- a/src/model/Client.model.ts
+++ b/src/model/Client.model.ts
@@ -8,3 +8,8 @@ export class Client {
         this.name = name;
     }
 }
+
+export interface IClient {
+    clientId: number;
+    clientName: string;
+}

--- a/src/model/Interview.model.ts
+++ b/src/model/Interview.model.ts
@@ -1,16 +1,18 @@
 import { InterviewFeedback } from "./Interview.feedback";
 import { IAssociateInput } from "./Associateinput.model";
+import { IClient } from "./Client.model";
 
 export interface Interview {
-  interviewId:      number,
-  managerId: number,
-  associateId: number,
-  scheduled: Date,
-  notified: Date,
-  reviewed: Date,
-  place: string,
-  feedback : InterviewFeedback,
-  associateInput : IAssociateInput
+  interviewId: number;
+  managerId: number;
+  associateId: number;
+  scheduled: Date;
+  notified: Date;
+  reviewed: Date;
+  place: string;
+  feedback : InterviewFeedback;
+  associateInput : IAssociateInput;
+  client: IClient;
 }
 
 /*

--- a/src/reducers/interview/index.ts
+++ b/src/reducers/interview/index.ts
@@ -130,7 +130,10 @@ export interface IInterviewListState {
 }
 
 export interface ITotalWeeklyState {
-    interviewList: Interview[]
+    interviewList: Interview[];
+    totalScheduled: number;
+    totalNotified: number;
+    totalReviewed: number;
 }
     
 export interface IInterviewState {

--- a/src/reducers/interview/index.ts
+++ b/src/reducers/interview/index.ts
@@ -13,6 +13,7 @@ import { feedbackRequestedChartReducer } from './feedbackrequested';
 import { jobDescriptionChartReducer } from './jobdesc.reducer';
 import { Client } from '../../model/Client.model';
 import { Interview } from '../../model/Interview.model';
+import { totalWeeklyReducer } from './total-weekly.reducer';
 
 export interface IReportFormState {
     
@@ -127,6 +128,10 @@ export interface IInterviewListState {
     currentPage : number,
     assocInput: any
 }
+
+export interface ITotalWeeklyState {
+    interviewList: Interview[]
+}
     
 export interface IInterviewState {
     interviewList : IInterviewListState,
@@ -138,7 +143,8 @@ export interface IInterviewState {
     associateInput: IAssociateInput,
     feedbackRequestedChart: IFeedbackRequestedChartState,
     feedbackDeliveredChart: IFeedbackDeliveredChartState,
-	jobDescriptionChart: IJobDescriptionChartState
+    jobDescriptionChart: IJobDescriptionChartState,
+    totalWeekly: ITotalWeeklyState
 }
 
 export const interviewState = combineReducers<IInterviewState>({
@@ -151,5 +157,6 @@ export const interviewState = combineReducers<IInterviewState>({
    associateInput: assocInputReducer,
    feedbackRequestedChart: feedbackRequestedChartReducer,
    feedbackDeliveredChart: feedbackDeliveredChartReducer,
-   jobDescriptionChart: jobDescriptionChartReducer
+   jobDescriptionChart: jobDescriptionChartReducer,
+   totalWeekly: totalWeeklyReducer
 })

--- a/src/reducers/interview/total-weekly.reducer.ts
+++ b/src/reducers/interview/total-weekly.reducer.ts
@@ -1,0 +1,19 @@
+import { ITotalWeeklyState } from ".";
+import { TOTAL_WEEKLY_TYPES } from "../../actions/total-weekly/total-weekly.actions";
+
+const initialState: ITotalWeeklyState = {
+  interviewList: []
+}
+
+export const totalWeeklyReducer = (state = initialState, action: any) => {
+  switch (action.type) {
+    case TOTAL_WEEKLY_TYPES.SET_INTERVIEW_LIST:
+      return {
+        ...state,
+        interviewList: action.payload
+      }
+
+    default:
+      return state
+  }
+}

--- a/src/reducers/interview/total-weekly.reducer.ts
+++ b/src/reducers/interview/total-weekly.reducer.ts
@@ -2,7 +2,10 @@ import { ITotalWeeklyState } from ".";
 import { TOTAL_WEEKLY_TYPES } from "../../actions/total-weekly/total-weekly.actions";
 
 const initialState: ITotalWeeklyState = {
-  interviewList: []
+  interviewList: [],
+  totalScheduled: 0,
+  totalNotified: 0,
+  totalReviewed: 0
 }
 
 export const totalWeeklyReducer = (state = initialState, action: any) => {
@@ -10,7 +13,10 @@ export const totalWeeklyReducer = (state = initialState, action: any) => {
     case TOTAL_WEEKLY_TYPES.SET_INTERVIEW_LIST:
       return {
         ...state,
-        interviewList: action.payload
+        interviewList: action.payload.interviewList,
+        totalScheduled: action.payload.totalScheduled,
+        totalNotified: action.payload.totalNotified,
+        totalReviewed: action.payload.totalReviewed
       }
 
     default:


### PR DESCRIPTION
This creates some charts (2 of them dynamically) for weekly interview data based on calendar week.
To actually see this component in use, you have to go back to the week of Feb. 24, 2019 because that's the only week with any mock data in the database.