### PR TITLE
fixed default loading routes to dashboard as a staging manager

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ class App extends React.Component {
             
             <div id="main-content-container">
               <Switch>
+                  <Route exact path='/' component ={DashboardRoutes}/>
                   <Route path='/management' component={ManagementRoutes}/>
                   <Route path='/interview' component={InterviewRoutes}/>
                   <Route path='/surveys' component ={SurveyRoutes}/>

--- a/src/actions/login/login.action.ts
+++ b/src/actions/login/login.action.ts
@@ -70,7 +70,7 @@ export const loginRequest = (username: string, password: string, history) => asy
         if(credentials.challengeName === 'NEW_PASSWORD_REQUIRED'){
             history.push('/management/reset-password')
         }else{
-            history.push('/surveys');
+            history.push('/');
         }
     } catch (error) {
         console.log(error);


### PR DESCRIPTION
manager can load to dashboard when they start localhost:3000, I signed up as a associate and still can load the dashboard by default, but the manager works now 